### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/Tests/Mako-IoT.Device.Services.WiFi.AP.Test/Mako-IoT.Device.Services.WiFi.AP.Test.nfproj
+++ b/Tests/Mako-IoT.Device.Services.WiFi.AP.Test/Mako-IoT.Device.Services.WiFi.AP.Test.nfproj
@@ -43,12 +43,12 @@
       <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.3\lib\nanoFramework.DependencyInjection.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.TestFramework, Version=2.1.87.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.87\lib\nanoFramework.TestFramework.dll</HintPath>
+    <Reference Include="nanoFramework.TestFramework, Version=2.1.93.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.93\lib\nanoFramework.TestFramework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.87\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.93\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/Tests/Mako-IoT.Device.Services.WiFi.AP.Test/packages.config
+++ b/Tests/Mako-IoT.Device.Services.WiFi.AP.Test/packages.config
@@ -3,5 +3,5 @@
   <package id="MakoIoT.Device.Services.Interface" version="1.0.45.4694" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
-  <package id="nanoFramework.TestFramework" version="2.1.87" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="nanoFramework.TestFramework" version="2.1.93" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.TestFramework from 2.1.87 to 2.1.93</br>
[version update]

### :warning: This is an automated update. :warning:
