### PR TITLE
Update 2 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.WiFi.AP.nuspec
+++ b/MakoIoT.Device.Services.WiFi.AP.nuspec
@@ -18,7 +18,7 @@
     <tags>nanoFramework C# csharp netmf netnf mako-iot wifi ap access point</tags>
     <dependencies>
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.47.44904" />
-      <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.38.31486" />
+      <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.39.7720" />
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.11" />
       <dependency id="nanoFramework.Iot.Device.DhcpServer" version="1.2.644" />

--- a/Tests/Mako-IoT.Device.Services.WiFi.AP.Test/Mako-IoT.Device.Services.WiFi.AP.Test.nfproj
+++ b/Tests/Mako-IoT.Device.Services.WiFi.AP.Test/Mako-IoT.Device.Services.WiFi.AP.Test.nfproj
@@ -40,11 +40,11 @@
     <Reference Include="nanoFramework.DependencyInjection, Version=1.1.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.11\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.TestFramework, Version=3.0.43.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.43\lib\nanoFramework.TestFramework.dll</HintPath>
+    <Reference Include="nanoFramework.TestFramework, Version=3.0.44.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.44\lib\nanoFramework.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.43\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.44\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Mako-IoT.Device.Services.WiFi.AP.Test/packages.config
+++ b/Tests/Mako-IoT.Device.Services.WiFi.AP.Test/packages.config
@@ -3,5 +3,5 @@
   <package id="MakoIoT.Device.Services.Interface" version="1.0.47.44904" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.11" targetFramework="netnano1.0" />
-  <package id="nanoFramework.TestFramework" version="3.0.43" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="nanoFramework.TestFramework" version="3.0.44" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>

--- a/src/MakoIoT.Device.Services.WiFi.AP/MakoIoT.Device.Services.WiFi.AP.nfproj
+++ b/src/MakoIoT.Device.Services.WiFi.AP/MakoIoT.Device.Services.WiFi.AP.nfproj
@@ -34,7 +34,7 @@
       <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.47.44904\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.Invoker, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.38.31486\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.39.7720\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>

--- a/src/MakoIoT.Device.Services.WiFi.AP/packages.config
+++ b/src/MakoIoT.Device.Services.WiFi.AP/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MakoIoT.Device.Services.Interface" version="1.0.47.44904" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.38.31486" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.39.7720" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.11" targetFramework="netnano1.0" />
   <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.644" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Utilities.Invoker from 1.0.38.31486 to 1.0.39.7720</br>Bumps nanoFramework.TestFramework from 3.0.43 to 3.0.44</br>
[version update]

### :warning: This is an automated update. :warning:
