### PR TITLE
Update 0 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.WiFi.AP.nuspec
+++ b/MakoIoT.Device.Services.WiFi.AP.nuspec
@@ -24,9 +24,9 @@
       <dependency id="nanoFramework.Iot.Device.DhcpServer" version="1.2.804" />
       <dependency id="nanoFramework.Runtime.Events" version="1.11.30" />
       <dependency id="nanoFramework.System.Collections" version="1.5.62" />
-      <dependency id="nanoFramework.System.Device.Wifi" version="1.5.123" />
-      <dependency id="nanoFramework.System.IO.Streams" version="1.1.88" />
-      <dependency id="nanoFramework.System.Net" version="1.11.32" />
+      <dependency id="nanoFramework.System.Device.Wifi" version="1.5.124" />
+      <dependency id="nanoFramework.System.IO.Streams" version="1.1.89" />
+      <dependency id="nanoFramework.System.Net" version="1.11.34" />
       <dependency id="nanoFramework.System.Text" version="1.3.29" />
       <dependency id="nanoFramework.System.Threading" version="1.1.49" />
     </dependencies>

--- a/src/MakoIoT.Device.Services.WiFi.AP/MakoIoT.Device.Services.WiFi.AP.nfproj
+++ b/src/MakoIoT.Device.Services.WiFi.AP/MakoIoT.Device.Services.WiFi.AP.nfproj
@@ -51,14 +51,14 @@
     <Reference Include="nanoFramework.System.Text, Version=1.3.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Text.1.3.29\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.Device.Wifi, Version=1.5.123.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Device.Wifi.1.5.123\lib\System.Device.Wifi.dll</HintPath>
+    <Reference Include="System.Device.Wifi, Version=1.5.124.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Device.Wifi.1.5.124\lib\System.Device.Wifi.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Streams, Version=1.1.88.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.88\lib\System.IO.Streams.dll</HintPath>
+    <Reference Include="System.IO.Streams, Version=1.1.89.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.89\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net, Version=1.11.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.32\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.11.34.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.34\lib\System.Net.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.49.41415, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.49\lib\System.Threading.dll</HintPath>

--- a/src/MakoIoT.Device.Services.WiFi.AP/packages.config
+++ b/src/MakoIoT.Device.Services.WiFi.AP/packages.config
@@ -7,9 +7,9 @@
   <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.804" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.30" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.62" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Device.Wifi" version="1.5.123" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.Streams" version="1.1.88" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.11.32" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Wifi" version="1.5.124" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.89" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.11.34" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.3.29" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.49" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.7.115" targetFramework="netnano1.0" developmentDependency="true" />


### PR DESCRIPTION
Bumps nanoFramework.System.Device.Wifi from 1.5.123 to 1.5.124</br>Bumps nanoFramework.System.IO.Streams from 1.1.88 to 1.1.89</br>Bumps nanoFramework.System.Net from 1.11.32 to 1.11.34</br>
[version update]

### :warning: This is an automated update. :warning:
